### PR TITLE
Check pubkey type from typeUrl instead of hard-coded prefix

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,7 +64,7 @@ function sortRelayTxs(txs, data) {
     txs.forEach((tx) => {
         let address = "";
         if (tx.authInfo.fee.granter == "") {
-            if (config.addr_prefix === "inj" || config.addr_prefix === "evmos") {
+            if (tx.authInfo.signerInfos[0].publicKey.typeUrl.includes("ethsecp256k1.PubKey")) {
                 let key = PubKey.toJSON(PubKey.decode(tx.authInfo.signerInfos[0].publicKey.value)).key.toString();
                 let pubkey = PublicKey.fromBase64(key)
                 address = pubkey.toAddress().toBech32(config.addr_prefix);


### PR DESCRIPTION
Relayers on (at least) Injective chain can use either ethsecp265k1 or secp256k1 key type. Thus the latter key type is converted incorrectly when hard-coding the type based on address prefix. This patch will check the key type from the type field to parse both of these options correctly.